### PR TITLE
updated Readme to have non-collapsing whitespace, and breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ If true, will write any soar output/printing to file agent-log.log
 #### Config File
 Instead of passing as arguments, you can pass in a filename as config_filename
 Each line in the file should be 'setting = value'
-Also, setting names use hyphens instead of underscores
-Example File:
-	agent-name = Rosie
-	agent-source = agent.soar
-	spawn-debugger = false
+Also, setting names use hyphens instead of underscores    
+Example File:    
+        agent-name = Rosie    
+        agent-source = agent.soar    
+        spawn-debugger = false    
 
 
 #### SoarAgent Methods


### PR DESCRIPTION
It is required to add special whitespaces in front of text to get it to indent.  Tab doesn't do it.    
It is required to add 4 spaces at the end of a line to get a line-break effect.  Carriage-return doesn't do it.

I cleaned up the part of the text in the "config file" area.